### PR TITLE
Add Cython to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 pillow
+Cython  # Needed for installation only


### PR DESCRIPTION
Cython is needed to install CharPyLS, but not to run it. However, since
Cython requirement is not listed pip installation will fail.